### PR TITLE
Change `(setf (point) ...)` and similar forms to `(goto-char ...)`

### DIFF
--- a/elfeed-curl.el
+++ b/elfeed-curl.el
@@ -194,17 +194,17 @@ output format."
         (call-process elfeed-curl-program-name nil t nil "--version")
         (let ((version
                (progn
-                 (setf (point) (point-min))
+                 (goto-char (point-min))
                  (when (re-search-forward "[.0-9]+" nil t)
                    (match-string 0))))
               (protocols
                (progn
-                 (setf (point) (point-min))
+                 (goto-char (point-min))
                  (when (re-search-forward "^Protocols: \\(.*\\)$" nil t)
                    (mapcar #'intern (split-string (match-string 1))))))
               (features
                (progn
-                 (setf (point) (point-min))
+                 (goto-char (point-min))
                  (when (re-search-forward "^Features: \\(.*\\)$")
                    (split-string (match-string 1))))))
           (setf (gethash elfeed-curl-program-name cache)
@@ -232,18 +232,18 @@ abcdefghijklmnopqrstuvwxyz|~"))
 (defun elfeed-curl--parse-write-out ()
   "Parse curl's write-out (-w) messages into `elfeed-curl--regions'."
   (widen)
-  (setf (point) (point-max)
-        elfeed-curl--regions ())
+  (goto-char (point-max))
+  (setf elfeed-curl--regions ())
   (while (> (point) (point-min))
     (search-backward elfeed-curl--token)
-    (cl-decf (point))
+    (goto-char (1- (point)))
     (let ((end (point)))
       (cl-destructuring-bind (_ . header) (read (current-buffer))
-        (setf (point) end)
+        (goto-char end)
         ;; Find next sentinel token
         (if (search-backward elfeed-curl--token nil t)
             (search-forward ")" nil t)
-          (setf (point) (point-min)))
+          (goto-char (point-min)))
         (let* ((header-start (point))
                (header-end (+ (point) header))
                (content-start (+ (point) header))
@@ -268,10 +268,10 @@ abcdefghijklmnopqrstuvwxyz|~"))
 Sets `elfeed-curl-headers'and `elfeed-curl-status-code'.
 Use `elfeed-curl--narrow' to select a header."
   (when (> (- (point-max) (point-min)) 0)
-    (setf (point) (point-max))
+    (goto-char (point-max))
     (re-search-backward "HTTP/[.0-9]+ +\\([0-9]+\\)")
     (setf elfeed-curl-status-code (string-to-number (match-string 1)))
-    (cl-loop initially (setf (point) (point-max))
+    (cl-loop initially (goto-char (point-max))
              while (re-search-backward "^\\([^:]+\\): +\\([^\r\n]+\\)" nil t)
              for key = (downcase (match-string 1))
              for value = (match-string 2)

--- a/elfeed-lib.el
+++ b/elfeed-lib.el
@@ -136,7 +136,7 @@ be relative to now (`elfeed-time-duration')."
 XML encoding declaration."
   (unless beg (setq beg (point-min)))
   (unless end (setq end (point-max)))
-  (setf (point) beg)
+  (goto-char beg)
   (when (re-search-forward
          "<\\?xml.*?encoding=[\"']\\([^\"']+\\)[\"'].*?\\?>" nil t)
     (let ((coding-system (intern-soft (downcase (match-string 1)))))
@@ -279,9 +279,9 @@ systems."
   "Place point after first blank line, for use with `url-retrieve'.
 If no such line exists, point is left in place."
   (let ((start (point)))
-    (setf (point) (point-min))
+    (goto-char (point-min))
     (unless (search-forward-regexp "^$" nil t)
-      (setf (point) start))))
+      (goto-char start))))
 
 (defun elfeed--shuffle (seq)
   "Destructively shuffle SEQ."

--- a/elfeed-search.el
+++ b/elfeed-search.el
@@ -118,13 +118,13 @@ When live editing the filter, it is bound to :live.")
 (defun elfeed-search-last-entry ()
   "Place point on last entry."
   (interactive)
-  (setf (point) (point-max))
+  (goto-char (point-max))
   (forward-line -1))
 
 (defun elfeed-search-first-entry ()
   "Place point on first entry."
   (interactive)
-  (setf (point) (point-min)))
+  (goto-char (point-min)))
 
 (defvar elfeed-search-mode-map
   (let ((map (make-sparse-keymap)))

--- a/tests/elfeed-lib-tests.el
+++ b/tests/elfeed-lib-tests.el
@@ -166,7 +166,7 @@
     (should (= (point) 12)))
   (with-temp-buffer
     (insert "aaaaa\nbbbb\ncccccc")
-    (setf (point) 5)
+    (goto-char 5)
     (elfeed-move-to-first-empty-line)
     (should (= (point) 5))))
 

--- a/tests/elfeed-tests.el
+++ b/tests/elfeed-tests.el
@@ -328,10 +328,10 @@
   (with-elfeed-test
     (with-temp-buffer
       (insert elfeed-test-rss)
-      (setf (point) (point-min))
+      (goto-char (point-min))
       (while (search-forward "http://" nil t)
         (replace-match "//" nil t))
-      (setf (point) (point-min))
+      (goto-char (point-min))
       (let ((xml (elfeed-xml-parse-region)))
         (cl-destructuring-bind (a b)
             (elfeed-entries-from-rss "http://example.com/" xml)
@@ -347,10 +347,10 @@
                          "https://www.wikipedia.org/")))))
     (with-temp-buffer
       (insert elfeed-test-atom)
-      (setf (point) (point-min))
+      (goto-char (point-min))
       (while (search-forward "base=\"http://" nil t)
         (replace-match "base=\"//" nil t))
-      (setf (point) (point-min))
+      (goto-char (point-min))
       (let ((xml (elfeed-xml-parse-region)))
         (cl-destructuring-bind (a b)
             (elfeed-entries-from-atom "http://example.com/" xml)


### PR DESCRIPTION
Emacs version 29.0.50 has deprecated the use of forms such as `(setf (point) n)`. The warning emitted is: -

Warning (bytecomp): ‘point’ is an obsolete generalized variable; use ‘goto-char’ instead.